### PR TITLE
Added an intermediate function which, if specified, is called on each error encountered

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,20 @@ backoff(dns.resolve, 'chilts.org', function(err, addresses, priorErrors) {
 });
 ```
 
+You can also provide an intermediate function which is called after each error. This method can be useful for logging
+or other operations between errors. By returning `false` you can cancel any additional tries.
+
+```
+var intermediate = function(err, tries, delay) {
+    console.log(err);   // last error
+    console.log(tries); // total number of tries performed thus far
+    console.log(delay); // the delay for the next attempt
+    return false;       // this will cancel additional tries
+};
+
+backoff(dns.resolve, 'chilts.org', intermediate, callback);
+```
+
 Notes:
 
 * 'err' contains the last error encountered (if maxTries was reached without success)
@@ -128,6 +142,9 @@ var backoff = oibackoff.backoff({
 
 Written by: [Andrew Chilton](http://chilts.org/) - [Blog](http://chilts.org/blog/) -
 [Twitter](https://twitter.com/andychilton).
+
+Contributors:
+[Daniel Stevens - Senico](http://senico.com/)
 
 ## License ##
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,22 @@
 {
   "name": "oibackoff",
   "description": "Incremental backoff flow-control for any : fn(function(err, data) { ... });",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "author": {
     "name": "Andrew Chilton",
     "email": "chilts@appsattic.com",
     "url": "http://www.chilts.org/"
   },
   "homepage": "https://github.com/appsattic/oibackoff",
-  "contributors": [],
+  "contributors": [{
+    "name": "Andrew Chilton",
+    "email": "chilts@appsattic.com",
+    "web": "http://www.chilts.org/" 
+  },{
+    "name": "Daniel Stevens",
+    "email": "daniel.stevens@senico.com",
+    "web": "http://senico.com/" 
+  }],
   "devDependencies": {
     "tap": ">= 0.2.5"
   },

--- a/test/basic.js
+++ b/test/basic.js
@@ -44,6 +44,9 @@ function statWithOneFail(filename, callback) {
         callback('Error', null);
         return;
     }
+    else {
+        count = 0;
+    }
     // now call the real one
     fs.stat(filename, callback);
 }
@@ -56,6 +59,25 @@ test("Basic successful callback", function (t) {
         t.equal(err, null, 'Error should be null');
         t.ok(stats.size, 'stats.size should be populated (with a number)');
         t.equal(priorErrors.length, 1, 'There should be one prior errors');
+        t.end();
+    });
+
+});
+
+test("Basic intermediate callback", function (t) {
+    t.plan(5);
+
+    // call a modified fs.stat which returns a fail on the first go
+    var intermediate = function (err, tries, delay) {
+        t.equal(err, 'Error', 'err should be \'Error\'');
+        t.equal(tries, 1, 'tries count should be 1');
+        t.ok(delay, "delay should be populated (with a number)");
+        return false;
+    };
+
+    backoff(statWithOneFail, __filename, intermediate, function(err, stats, priorErrors) {
+        t.equal(err, 'Error', 'err should be \'Error\'');
+        t.equal(priorErrors.length, 0, 'There should be no prior errors');
         t.end();
     });
 


### PR DESCRIPTION
Added the ability to provide an optional intermediate function which is called after each error. This method can be useful for logging
or other operations between errors. By returning `false` you can cancel any additional tries.

```
var intermediate = function(err, tries, delay) {
    console.log(err);   // last error
    console.log(tries); // total number of tries performed thus far
    console.log(delay); // the delay for the next attempt
    return false;       // this will cancel additional tries
};

backoff(dns.resolve, 'chilts.org', intermediate, callback);
```
